### PR TITLE
attemps fixing cocos2d-x issue 19188

### DIFF
--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -1001,6 +1001,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                         isClaimed = listener->onTouchBegan(touches, event);
                         if (isClaimed && listener->_isRegistered)
                         {
+                            touches->retain();
                             listener->_claimedTouches.push_back(touches);
                         }
                     }
@@ -1025,6 +1026,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                             }
                             if (listener->_isRegistered)
                             {
+                                touches->release();
                                 listener->_claimedTouches.erase(removedIter);
                             }
                             break;
@@ -1035,6 +1037,7 @@ void EventDispatcher::dispatchTouchEvent(EventTouch* event)
                             }
                             if (listener->_isRegistered)
                             {
+                                touches->release();
                                 listener->_claimedTouches.erase(removedIter);
                             }
                             break;


### PR DESCRIPTION
attemps fixing cocos2d/cocos2d-x/19188 (WARNING: see note below!)

Attempts to fix a disappearing Ended/Cancel event and a memory reuse.

It might introduce a small memory leak as touches are retained in the
Began event, but never released as the Ended/Cancel never arrives.

The proper solution should be investigate why the touches are reused
but the event is never called leading to this bug.

See https://github.com/cocos2d/cocos2d-x/issues/19188 for full details.
